### PR TITLE
OperatorManager TODO

### DIFF
--- a/featuretools/mkfeat/opmgr.py
+++ b/featuretools/mkfeat/opmgr.py
@@ -1,18 +1,17 @@
+import featuretools as ft
+from featuretools.primitives import utils
+
 class OperatorManager:
     """
-    현재 설계상으로는 특징 추출시 연산자를 사용자가 지정하도록 되어 있으나, 사용자가 연산자를 지정하지 않는 방식으로 특징 추출이 구현될
-    수 있음. 이러한 경우를 지원하는 용도로 이 클래스가 향후 활용될 수 있음
-    지금 구현에서는 사용자는 단순히 operator 이름만 지정하는데, featuretool의 dfs 입력은 transform이나 aggregation 타입을 구분하여
-    operator를 지정해야 함. 이를 위해 사용자가 지정한 operator에 대해 해당 유형을 적절히 반환할 수 있도록 해야 함
+    현재 설계상으로는 특징 추출시 연산자를 사용자가 지정하도록 되어 있으나, 사용자가 연산자를 지정하지 않는 방식으로 특징 추출이 구현될 수 있음.
+    이러한 경우를 지원하는 용도로 이 클래스가 향후 활용될 수 있음
+    지금 구현에서는 사용자는 단순히 operator 이름만 지정하는데, featuretool의 dfs 입력은 transform이나 aggregation 타입을 구분하여 operator를 지정해야 함.
+    이를 위해 사용자가 지정한 operator에 대해 해당 유형을 적절히 반환할 수 있도록 해야 함
     """
     def __init__(self, operators):
-        self.operators = set(operators)
-        self.transforms = {
-            "absolute", "day", "haversine", "month", "num_characters", "num_words", "weekday", "year"
-        }
-        self.aggregations = {
-            "count", "max", "mode", "num_unique", "percent_true", "skew",  "std", "sum"
-        }
+        self.operators = set(str.lower(op) for op in operators)
+        self.transforms = utils.get_transform_primitives().keys()
+        self.aggregations = utils.get_aggregation_primitives().keys()
 
     def get_transform_operators(self):
         return set(self.operators & self.transforms)

--- a/featuretools/mkfeat/opmgr.py
+++ b/featuretools/mkfeat/opmgr.py
@@ -3,15 +3,24 @@ from featuretools.primitives import utils
 
 class OperatorManager:
     """
-    현재 설계상으로는 특징 추출시 연산자를 사용자가 지정하도록 되어 있으나, 사용자가 연산자를 지정하지 않는 방식으로 특징 추출이 구현될 수 있음.
-    이러한 경우를 지원하는 용도로 이 클래스가 향후 활용될 수 있음
-    지금 구현에서는 사용자는 단순히 operator 이름만 지정하는데, featuretool의 dfs 입력은 transform이나 aggregation 타입을 구분하여 operator를 지정해야 함.
-    이를 위해 사용자가 지정한 operator에 대해 해당 유형을 적절히 반환할 수 있도록 해야 함
+    1.
+    현재 설계 상으로는 특징 추출시 연산자를 사용자가 지정하도록 되어 있으나, 사용자가 연산자를 지정하지 않는 방식으로 특징 추출이 구현될 수 있음.
+    이러한 경우, 전체 operator를 반환하여 특징 추출을 지원하는 용도로 이 클래스를 활용함.
+    2.
+    지금 구현에서는 사용자가 단순히 operator 이름만 지정하는데, featuretool의 dfs 입력은 transform이나 aggregation 타입을 구분하여 operator를 지정해야 함.
+    이를 위해 사용자가 지정한 operator에 해당하는 유형을 반환함.
     """
     def __init__(self, operators):
-        self.operators = set(str.lower(op) for op in operators)
+        if not operators:
+            self.operators = self.get_all_operators()
+        else:
+            self.operators = set(str.lower(op) for op in operators)
         self.transforms = utils.get_transform_primitives().keys()
         self.aggregations = utils.get_aggregation_primitives().keys()
+
+    def get_all_operators(self):
+        operators_df = ft.list_primitives()
+        return set(operators_df['name'])
 
     def get_transform_operators(self):
         return set(self.operators & self.transforms)


### PR DESCRIPTION
### Summary
OperatorManager TODO 구현 : `opmgr.py`에 다음과 같은 사항 구현
- 사용자가 단순히 operator 이름만 지정하더라도 featuretool의 dfs 입력은 transform이나 aggregation 타입을 구분하여 operator를 지정해야 하므로, 이를 위해 사용자가 지정한 operator에 대해 해당 유형을 적절히 반환할 수 있도록 해야 함
- 현재 설계상으로는 특징 추출시 연산자를 사용자가 지정하도록 되어 있으나, 사용자가 연산자를 지정하지 않는 방식으로 특징 추출이 구현될 수 있음. 전체 operators를 반환하여 이러한 경우를 지원하는 용도로 이 클래스가 향후 활용될 수 있음